### PR TITLE
Remove npm cache from github CI (#84)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,5 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     - run: npm install
     - run: npm test


### PR DESCRIPTION
## Description
Removed npm cache from CI.

Fixes #84 

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes